### PR TITLE
chore: compress image size via single command, remove package

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,11 +2,11 @@ FROM docker
 
 LABEL tools="docker-image, gitlab-aws, aws, helm, helm-charts, docker, gitlab, gitlab-ci, kubectl, s3, aws-iam-authenticator, ecr, bash, envsubst, alpine, curl, python3, pip3, git"
 # version is kubectl version
-LABEL version="1.14.6"
+LABEL version="1.17.9"
 LABEL description="An Alpine based docker image contains a good combination of commenly used tools\
     to build, package as docker image, login and push to AWS ECR, AWS authentication and all Kuberentes staff. \
     tools included: Docker, AWS-CLI, Kubectl, Helm, Curl, Python, Envsubst, Python, Pip, Git, Bash, AWS-IAM-Auth."
-LABEL maintainer="eng.ahmed.srour@gmail.com"
+LABEL maintainer="eng.ahmed.srour@gmail.com, 3856350+guitarrapc@users.noreply.github.com"
 
 # https://docs.aws.amazon.com/eks/latest/userguide/install-kubectl.html
 ENV AWS_CLI_VERSION="1.18.31" \
@@ -42,25 +42,25 @@ RUN set -x && \
 # omit docker-compose. don't need without dind, let's remove in this fork.
 # RUN pip3 --no-cache-dir install docker-compose 
 
-ADD https://github.com/jwilder/dockerize/releases/download/v$DOCKERIZE_VERSION/dockerize-alpine-linux-amd64-v${DOCKERIZE_VERSION}.tar.gz dockerize-alpine-linux-amd64.tar.gz
-RUN tar -C /usr/local/bin -xzvf dockerize-alpine-linux-amd64.tar.gz && \
-    rm dockerize-alpine-linux-amd64.tar.gz
+RUN curl -sL https://github.com/jwilder/dockerize/releases/download/v$DOCKERIZE_VERSION/dockerize-alpine-linux-amd64-v${DOCKERIZE_VERSION}.tar.gz -o dockerize-alpine-linux-amd64.tar.gz \
+    && tar -C /usr/local/bin -xzvf dockerize-alpine-linux-amd64.tar.gz \
+    && rm dockerize-alpine-linux-amd64.tar.gz
 
-ADD https://github.com/a8m/envsubst/releases/download/v${ENVSUBST_VERSION}/envsubst-Linux-x86_64 /usr/local/bin/envsubst
-RUN chmod +x /usr/local/bin/envsubst
+RUN curl -sL https://github.com/a8m/envsubst/releases/download/v${ENVSUBST_VERSION}/envsubst-Linux-x86_64 -o /usr/local/bin/envsubst \
+    && chmod +x /usr/local/bin/envsubst
 
-ADD https://amazon-eks.s3-us-west-2.amazonaws.com/${AWS_IAM_AUTHENTICATOR_VERSION}/${AWS_IAM_AUTHENTICATOR_DATE}/bin/linux/amd64/aws-iam-authenticator /usr/local/bin/aws-iam-authenticator
-RUN chmod +x /usr/local/bin/aws-iam-authenticator
+RUN curl -sL https://amazon-eks.s3-us-west-2.amazonaws.com/${AWS_IAM_AUTHENTICATOR_VERSION}/${AWS_IAM_AUTHENTICATOR_DATE}/bin/linux/amd64/aws-iam-authenticator -o /usr/local/bin/aws-iam-authenticator \
+    && chmod +x /usr/local/bin/aws-iam-authenticator
 
-ADD https://amazon-eks.s3-us-west-2.amazonaws.com/${KUBECTL_VERSION}/${KUBECTL_DATE}/bin/linux/amd64/kubectl /usr/local/bin/kubectl
-RUN chmod +x /usr/local/bin/kubectl
+RUN curl -sL https://amazon-eks.s3-us-west-2.amazonaws.com/${KUBECTL_VERSION}/${KUBECTL_DATE}/bin/linux/amd64/kubectl -o /usr/local/bin/kubectl \
+    && chmod +x /usr/local/bin/kubectl
 
-ADD https://github.com/garethr/kubeval/releases/download/${KUBEVAL_VERSION}/kubeval-linux-amd64.tar.gz kubeval-linux-amd64.tar.gz
-RUN tar -C /usr/local/bin -xzvf kubeval-linux-amd64.tar.gz && \
-    rm kubeval-linux-amd64.tar.gz
+RUN curl -sL https://github.com/garethr/kubeval/releases/download/${KUBEVAL_VERSION}/kubeval-linux-amd64.tar.gz -o kubeval-linux-amd64.tar.gz \
+    && tar -C /usr/local/bin -xzvf kubeval-linux-amd64.tar.gz \
+    && rm kubeval-linux-amd64.tar.gz
 
-ADD https://github.com/mozilla/sops/releases/download/v${SOPS_VERSION}/sops-v${SOPS_VERSION}.linux /usr/local/bin/sops
-RUN chmod +x /usr/local/bin/sops
+RUN curl -sL https://github.com/mozilla/sops/releases/download/v${SOPS_VERSION}/sops-v${SOPS_VERSION}.linux -o /usr/local/bin/sops \
+    && chmod +x /usr/local/bin/sops
 
 # Install GIT
 RUN apk add --no-cache git
@@ -71,9 +71,11 @@ RUN apk add --no-cache git
 #RUN git clone https://github.com/hypnoglow/helm-s3.git
 
 # Install Helm
-ADD https://get.helm.sh/helm-v${HELM_VERSION}-linux-amd64.tar.gz helm-linux-amd64.tar.gz
-RUN tar -zxvf helm-linux-amd64.tar.gz && \
-    mv linux-amd64/helm /usr/local/bin/helm
+RUN curl -sL https://get.helm.sh/helm-v${HELM_VERSION}-linux-amd64.tar.gz -o helm-linux-amd64.tar.gz \
+    && tar -zxvf helm-linux-amd64.tar.gz \
+    && mv linux-amd64/helm /usr/local/bin/helm \
+    && rm helm-linux-amd64.tar.gz \
+    && rm -rf linux-amd64
 
 # Install Helm S3 Plugin
 RUN helm plugin install https://github.com/hypnoglow/helm-s3.git --version ${HELM_S3_VERSION}


### PR DESCRIPTION
deprecate ADD and move to single curl and remove packages

## changes

Summary

```
$ docker image ls | grep guitarrapc/docker-awscli-kubectl
guitarrapc/docker-awscli-kubectl                      shrink              42a6f2054af6        2 minutes ago       613MB
guitarrapc/docker-awscli-kubectl                      latest              337b959226ca        3 months ago        744MB
```

before

```
$ dive guitarrapc/docker-awscli-kubectl:latest
```
![image](https://user-images.githubusercontent.com/3856350/90997463-90ad0980-e5fc-11ea-8c6e-b44a3f37a67f.png)


after

```
$ docker build -t guitarrapc/docker-awscli-kubectl:shrink .
$ dive guitarrapc/docker-awscli-kubectl:shrink
```

![image](https://user-images.githubusercontent.com/3856350/90997810-82abb880-e5fd-11ea-8b8c-97003c7a3727.png)
